### PR TITLE
Update action groups

### DIFF
--- a/wti/remote/meta/runtime.yml
+++ b/wti/remote/meta/runtime.yml
@@ -1,0 +1,11 @@
+action_groups:
+  cpm:
+  - cpm_plugconfig
+  - cpm_plugcontrol
+  - cpm_serial_port_config
+  - cpm_serial_port_info
+  - cpm_user
+
+action_groups_redirection:
+  cpm:
+    redirect: cpm

--- a/wti/remote/meta/runtime.yml
+++ b/wti/remote/meta/runtime.yml
@@ -5,7 +5,3 @@ action_groups:
   - cpm_serial_port_config
   - cpm_serial_port_info
   - cpm_user
-
-action_groups_redirection:
-  cpm:
-    redirect: cpm


### PR DESCRIPTION
This will keep backwards compatibility with playbooks using wti.remote content with module_defaults groups - for example

```
module_defaults:
  group/cpm:
    # set common options with default values
    option: value
tasks:
  # uses the module_default group value for the option
  - cpm_user:

  # should use the module_default group value for the option
  - community.kubernetes.cpm_user:
```

ansible/ansible#67291 adds support so the collection is no longer reliant on routing and the entries in core to keep things from breaking and now can define their own. This will also fix using `group/cpm:` with fully qualified module names.
