### PR TITLE
cpm_serial_port_config - Fix incorrect stopbits parameters

### DIFF
--- a/wti/remote/plugins/modules/cpm_serial_port_config.py
+++ b/wti/remote/plugins/modules/cpm_serial_port_config.py
@@ -92,7 +92,7 @@ options:
         choices: [ 0, 1, 2, 3 ]
     stopbits:
         description:
-            - This is the stop bits to assign to the port, 0=1 Stop Bit, 1=2 Stop Bit.
+            - This is the stop bits to assign to the port, 1=1 Stop Bit, 2=2 Stop Bit.
         type: int
         required: false
         choices: [ 0, 1 ]
@@ -159,7 +159,7 @@ EXAMPLES = """
     portname: "RouterLabel"
     baud: "7"
     handshake: "1"
-    stopbits: "0"
+    stopbits: "1"
     parity: "0"
     mode: "0"
     cmd: "0"
@@ -270,7 +270,7 @@ def run_module():
         portname=dict(type='str', required=False, default=None),
         baud=dict(type='int', required=False, default=None, choices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
         handshake=dict(type='int', required=False, default=None, choices=[0, 1, 2, 3]),
-        stopbits=dict(type='int', required=False, default=None, choices=[0, 1]),
+        stopbits=dict(type='int', required=False, default=None, choices=[1, 2]),
         parity=dict(type='int', required=False, default=None, choices=[0, 1, 2, 3, 4, 5]),
         mode=dict(type='int', required=False, default=None, choices=[0, 1, 2, 3, 4]),
         cmd=dict(type='int', required=False, default=None, choices=[0, 1]),


### PR DESCRIPTION
The documentation and argument spec for the `cpm_serial_port_config` module indicate `stopbits` `0` and `1` are valid values, but when using a value of `0`, the API returns an error.

Update the documentation and argument spec to reflect the correct values for stopbits, which is 1 and 2.

Tested with the following CPM and firmware:
```
        PARAMETER         |              VALUE               |
--------------------------+----------------------------------+
Product                   | CPM-800-1-EC                     |
SW Version                | 6.60 30 Jul 2020                 |
Serial Number             | 01912820171004                   |
Asset Tag                 | (undefined)                      |
Analog Modem Phone Number | (undefined)                      |
Modem Installed           | No                               |
GIG / DUAL-PHY            | Yes / Yes                        |
CPU / Board Program Date  | ARM / 5-10-2017                  |
RAM / FLASH               | 512 MB / 128 MB                  |
Line Input Count / Rating | 2  / 20 Amps                     |
Current Monitor           | Yes                              |
Key Length                | 2048                             |
OpenSSL Version           | 1.0.2t-fips  10 Sep 2019         |
OpenSSH Version           | 8.0p1                            |
Apache Version            | 2.4.39                           |
RESTful Versions          | v1.0, v2 (Jan19)                 |
```

#### Steps to Reproduce
Run the following playbook
```yaml
- name: Configure PDU
  hosts: localhost
  connection: local
  become: no
  gather_facts: no

  module_defaults:
    group/cpm:
      cpm_url: cpm-1.acme.com
      cpm_username: bugs
      cpm_password: "{{ vault_cpm_password }}"

  tasks:
    - name: Configure serial ports
      wti.remote.cpm_serial_port_config:
        port: 1
        portname: Router
        stopbits: 1
```


#### Expected Results

```
> ansible-playbook pdu.yml -vvv
...

PLAYBOOK: pdu.yml ****************************************************************************************************************************************

PLAY [Configure PDU] *************************************************************************************************************************************

TASK [Configure serial ports] ****************************************************************************************************************************
changed: [localhost] => {
    "changed": true,
    "data": {
        "serialports": [
            {
                "baud": "8",
                "break": "1",
                "cmd": "1",
                "connstatus": "Free",
                "echo": "1",
                "handshake": "0",
                "logoff": "^X",
                "mode": "0",
                "parity": "3",
                "port": "1",
                "portname": "Router",
                "seq": "2",
                "stopbits": "1",
                "tout": "0"
            }
        ],
        "status": {
            "code": "0",
            "text": "ok"
        }
    },
    "invocation": {
        "module_args": {
            "baud": null,
            "break_allow": null,
            "cmd": null,
            "cpm_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "cpm_url": "cpm-1.acme.com",
            "cpm_username": "bugs",
            "echo": null,
            "handshake": null,
            "logoff": null,
            "mode": null,
            "parity": null,
            "port": 1,
            "portname": "Router",
            "seq": null,
            "stopbits": 1,
            "tout": null,
            "use_https": true,
            "use_proxy": false,
            "validate_certs": true
        }
    }
}

PLAY RECAP ***********************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

### Actual Results

The API returns an error if provided with a value of `0` for `stopbits`.
```
> ansible-playbook pdu.yml -vvv

PLAYBOOK: pdu.yml ****************************************************************************************************************************************
1 plays in pdu.yml

PLAY [Configure PDU] *************************************************************************************************************************************

TASK [Configure serial ports] ****************************************************************************************************************************
The full traceback is:
  File "/tmp/ansible_wti.remote.cpm_serial_port_config_payload_hmf9gojs/ansible_wti.remote.cpm_serial_port_config_payload.zip/ansible_collections/wti/remote/plugins/modules/cpm_serial_port_config.py", line 333, in run_module
  File "/tmp/ansible_wti.remote.cpm_serial_port_config_payload_hmf9gojs/ansible_wti.remote.cpm_serial_port_config_payload.zip/ansible/module_utils/urls.py", line 1393, in open_url
    return Request().open(method, url, data=data, headers=headers, use_proxy=use_proxy,
  File "/tmp/ansible_wti.remote.cpm_serial_port_config_payload_hmf9gojs/ansible_wti.remote.cpm_serial_port_config_payload.zip/ansible/module_utils/urls.py", line 1304, in open
    return urllib_request.urlopen(request, None, timeout)
  File "/Users/bugs/.pyenv/versions/3.8.5/lib/python3.8/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/Users/bugs/.pyenv/versions/3.8.5/lib/python3.8/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/Users/bugs/.pyenv/versions/3.8.5/lib/python3.8/urllib/request.py", line 640, in http_response
    response = self.parent.error(
  File "/Users/bugs/.pyenv/versions/3.8.5/lib/python3.8/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/Users/bugs/.pyenv/versions/3.8.5/lib/python3.8/urllib/request.py", line 502, in _call_chain
    result = func(*args)
  File "/Users/bugs/.pyenv/versions/3.8.5/lib/python3.8/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "baud": null,
            "break_allow": null,
            "cmd": null,
            "cpm_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "cpm_url": "cpm-1.acme.com",
            "cpm_username": "bugs",
            "echo": null,
            "handshake": null,
            "logoff": null,
            "mode": null,
            "parity": null,
            "port": 1,
            "portname": "Router",
            "seq": null,
            "stopbits": 0,
            "tout": null,
            "use_https": true,
            "use_proxy": false,
            "validate_certs": false
        }
    }
}

MSG:

POST: Received HTTP error for https://cpm-1.acme.com/api/v2/config/serialports : HTTP Error 400: object invalid

PLAY RECAP ***********************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

```