### PR TITLE
Certification Sanity Fixes

### DIFF
--- a/wti/remote/meta/runtime.yml
+++ b/wti/remote/meta/runtime.yml
@@ -32,4 +32,3 @@ action_groups:
   - cpm_time_config
   - cpm_time_info
   - cpm_user
-

--- a/wti/remote/playbooks/cpm_syslog_client/syslog_client_info.yml
+++ b/wti/remote/playbooks/cpm_syslog_client/syslog_client_info.yml
@@ -27,4 +27,3 @@
   - name: dump test output
     debug:
       msg: "{{ testout['data'] }}"
-

--- a/wti/remote/playbooks/cpm_syslog_server/syslog_server_config.yml
+++ b/wti/remote/playbooks/cpm_syslog_server/syslog_server_config.yml
@@ -37,4 +37,3 @@
   - name: dump test output
     debug:
       msg: "{{ testout['data'] }}"
-

--- a/wti/remote/playbooks/cpm_syslog_server/syslog_server_info.yml
+++ b/wti/remote/playbooks/cpm_syslog_server/syslog_server_info.yml
@@ -27,4 +27,3 @@
   - name: dump test output
     debug:
       msg: "{{ testout['data'] }}"
-

--- a/wti/remote/plugins/lookup/cpm_config_backup.py
+++ b/wti/remote/plugins/lookup/cpm_config_backup.py
@@ -104,7 +104,6 @@ data:
 """
 
 import base64
-import json
 import datetime
 
 from ansible.module_utils.basic import AnsibleModule

--- a/wti/remote/plugins/lookup/cpm_config_restore.py
+++ b/wti/remote/plugins/lookup/cpm_config_restore.py
@@ -117,8 +117,6 @@ data:
 """
 
 import base64
-import json
-import datetime
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text, to_bytes, to_native

--- a/wti/remote/plugins/lookup/cpm_firmware_update.py
+++ b/wti/remote/plugins/lookup/cpm_firmware_update.py
@@ -151,15 +151,12 @@ import base64
 import os
 import json
 import tempfile
-import traceback
-import shutil
 import requests
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text, to_bytes, to_native
 from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import open_url, ConnectionError, SSLValidationError
-from ansible.module_utils.urls import fetch_url, url_argument_spec
 
 
 def run_module():

--- a/wti/remote/plugins/lookup/cpm_hostname_info.py
+++ b/wti/remote/plugins/lookup/cpm_hostname_info.py
@@ -132,30 +132,39 @@ def run_module():
     # define the available arguments/parameters that a user can pass to
     # the module
     module_args = dict(
-        cpm_url=dict(type='str', required=True),
-        cpm_username=dict(type='str', required=True),
-        cpm_password=dict(type='str', required=True, no_log=True),
-        use_https=dict(type='bool', default=True),
-        validate_certs=dict(type='bool', default=True),
-        use_proxy=dict(type='bool', default=False)
+        cpm_url=dict(type="str", required=True),
+        cpm_username=dict(type="str", required=True),
+        cpm_password=dict(type="str", required=True, no_log=True),
+        use_https=dict(type="bool", default=True),
+        validate_certs=dict(type="bool", default=True),
+        use_proxy=dict(type="bool", default=False),
     )
 
-    result = dict(
-        changed=False,
-        data=''
-    )
+    result = dict(changed=False, data="")
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
 
-    auth = to_text(base64.b64encode(to_bytes('{0}:{1}'.format(to_native(module.params['cpm_username']), to_native(module.params['cpm_password'])),
-                   errors='surrogate_or_strict')))
+    auth = to_text(
+        base64.b64encode(
+            to_bytes(
+                "{0}:{1}".format(
+                    to_native(module.params["cpm_username"]),
+                    to_native(module.params["cpm_password"]),
+                ),
+                errors="surrogate_or_strict",
+            )
+        )
+    )
 
-    if module.params['use_https'] is True:
+    if module.params["use_https"] is True:
         protocol = "https://"
     else:
         protocol = "http://"
 
-    fullurl = ("%s%s/api/v2/config/hostname" % (protocol, to_native(module.params['cpm_url'])))
+    fullurl = "%s%s/api/v2/config/hostname" % (
+        protocol,
+        to_native(module.params["cpm_url"]),
+    )
 
     try:
         response = open_url(fullurl, data=None, method='GET', validate_certs=module.params['validate_certs'], use_proxy=module.params['use_proxy'],

--- a/wti/remote/plugins/lookup/cpm_interface_info.py
+++ b/wti/remote/plugins/lookup/cpm_interface_info.py
@@ -149,10 +149,10 @@ def run_module():
         cpm_password=dict(type='str', required=True, no_log=True),
         face=dict(type='list', elements='raw', default=None),
         interface=dict(
-                  required=False,
-                  type="str",
-                  choices=["eth0", "eth1", "ppp0", "qmimux0"],
-                 ),
+            required=False,
+            type="str",
+            choices=["eth0", "eth1", "ppp0", "qmimux0"],
+        ),
         use_https=dict(type='bool', default=True),
         validate_certs=dict(type='bool', default=True),
         use_proxy=dict(type='bool', default=False)

--- a/wti/remote/plugins/lookup/cpm_snmp_config.py
+++ b/wti/remote/plugins/lookup/cpm_snmp_config.py
@@ -246,7 +246,6 @@ data:
                 "privproto": "0", "index": "1" }]}}}]
 """
 
-from collections import OrderedDict
 import base64
 import json
 

--- a/wti/remote/plugins/lookup/cpm_syslog_client_config.py
+++ b/wti/remote/plugins/lookup/cpm_syslog_client_config.py
@@ -187,7 +187,6 @@ data:
                  {"address": "", "port": "514", "transport": "0", "secure": "0", "index": "4"}]}}}
 """
 
-from collections import OrderedDict
 import base64
 import json
 

--- a/wti/remote/plugins/lookup/cpm_syslog_server_config.py
+++ b/wti/remote/plugins/lookup/cpm_syslog_server_config.py
@@ -188,7 +188,6 @@ data:
                "enable": 0, "port": "514", "secure": "0", "transport": "0"}}]}}
 """
 
-from collections import OrderedDict
 import base64
 import json
 

--- a/wti/remote/plugins/modules/cpm_config_backup.py
+++ b/wti/remote/plugins/modules/cpm_config_backup.py
@@ -104,7 +104,6 @@ data:
 """
 
 import base64
-import json
 import datetime
 
 from ansible.module_utils.basic import AnsibleModule

--- a/wti/remote/plugins/modules/cpm_config_restore.py
+++ b/wti/remote/plugins/modules/cpm_config_restore.py
@@ -117,8 +117,6 @@ data:
 """
 
 import base64
-import json
-import datetime
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text, to_bytes, to_native

--- a/wti/remote/plugins/modules/cpm_firmware_update.py
+++ b/wti/remote/plugins/modules/cpm_firmware_update.py
@@ -151,8 +151,6 @@ import base64
 import os
 import json
 import tempfile
-import traceback
-import shutil
 
 try:
     import requests
@@ -164,7 +162,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text, to_bytes, to_native
 from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import open_url, ConnectionError, SSLValidationError
-from ansible.module_utils.urls import fetch_url, url_argument_spec
 
 
 def run_module():

--- a/wti/remote/plugins/modules/cpm_snmp_config.py
+++ b/wti/remote/plugins/modules/cpm_snmp_config.py
@@ -245,7 +245,6 @@ data:
                 "privproto": "0", "index": "1" }]}}}]
 """
 
-from collections import OrderedDict
 import base64
 import json
 

--- a/wti/remote/plugins/modules/cpm_syslog_client_config.py
+++ b/wti/remote/plugins/modules/cpm_syslog_client_config.py
@@ -188,7 +188,6 @@ data:
                  {"address": "", "port": "514", "transport": "0", "secure": "0", "index": "4"}]}}}
 """
 
-from collections import OrderedDict
 import base64
 import json
 

--- a/wti/remote/plugins/modules/cpm_syslog_server_config.py
+++ b/wti/remote/plugins/modules/cpm_syslog_server_config.py
@@ -188,7 +188,6 @@ data:
                "enable": 0, "port": "514", "secure": "0", "transport": "0"}}]}}
 """
 
-from collections import OrderedDict
 import base64
 import json
 


### PR DESCRIPTION
small patch containing some sanity fixes around unused imports, pep8 spacing issues and some yaml_lint fixes. There is some outstanding issues that will need to be addressed by the main team as they effect direct code usage from a user so I will leave that up to you all to address. those errors are below as well what I tested against locally on my machine.

*ansible version tested locally*
```
➜  remote git:(pylint_fixes) ansible --version
ansible [core 2.15.2]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/thedoubl3j/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/thedoubl3j/.local/lib/python3.11/site-packages/ansible
  ansible collection location = /home/thedoubl3j/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/thedoubl3j/.local/bin/ansible
  python version = 3.11.4 (main, Jun  7 2023, 00:00:00) [GCC 12.3.1 20230508 (Red Hat 12.3.1-1)] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
```

*errors that need to be addressed by dev team*
```
ERROR: plugins/modules/cpm_firmware_update.py:323:24: ansible-bad-function: Call module.log or module.debug instead of builtins.print 
ERROR: plugins/modules/cpm_firmware_update.py:325:24: consider-using-sys-exit: Consider using 'sys.exit' instead
ERROR: plugins/lookup/cpm_firmware_update.py:316:24: consider-using-sys-exit: Consider using 'sys.exit' instead 
```
