### PR TITLE
ci: fix branch name in GHA trigger

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -37,8 +37,7 @@ on:
   # Run CI against all pushes (direct commits, also merged PRs), Pull Requests
   push:
     branches:
-      - main
-      - stable-*
+      - master
   pull_request:
   # Run CI once per day (at 06:00 UTC)
   # This ensures that even if there haven't been commits that we are still


### PR DESCRIPTION
The branch name for this repository is `master` not `main`, so the CI configuration needs to be adjusted accordingly.